### PR TITLE
bug(EJ2-832884): rowselection

### DIFF
--- a/ej2-javascript/code-snippet/gantt/how-to-draganddrop-cs1/index.js
+++ b/ej2-javascript/code-snippet/gantt/how-to-draganddrop-cs1/index.js
@@ -10,6 +10,10 @@ var treeObj = new ej.navigations.TreeView({
           var index = ganttChart.treeGrid.getRows().indexOf(gridEle);
           ganttChart.selectRow(index);
         }
+        if (chartEle) {
+            var index = chartEle.ariaRowIndex;
+            ganttChart.selectRow(Number(index));
+        }
         var record= args.draggedNodeData;
         var selectedData = ganttChart.flatData[ganttChart.selectedRowIndex];
         var selectedDataResource = selectedData.taskData.resources;

--- a/ej2-javascript/code-snippet/gantt/how-to-draganddrop-cs1/index.ts
+++ b/ej2-javascript/code-snippet/gantt/how-to-draganddrop-cs1/index.ts
@@ -20,6 +20,10 @@ let treeObj: TreeView = new TreeView({
           var index = ganttObj.treeGrid.getRows().indexOf(gridEle);
           ganttObj.selectRow(index);
         }
+        if (chartEle) {
+            var index = chartEle.ariaRowIndex;
+            ganttChart.selectRow(Number(index));
+        }
         let record: any = args.draggedNodeData;
         let selectedData = ganttObj.flatData[ganttObj.selectedRowIndex];
         let selectedDataResource = selectedData.taskData.resources;


### PR DESCRIPTION
### Bug description

Row Selection behaviour occurs differently in grid and gantt

### Root cause

Row Selection behaviour occurs differently in grid and gantt  some change in source level 

### Reason for not identifying earlier

- [x] Guidelines/documents are not followed

    - Common guidelines / Core team guideline

    - Specification document

    - Requirement document
- [ ] Guidelines/documents are not given

    - Common guidelines / Core team guideline

    - Specification document

    - Requirement document
	
### Reason:

Guidelines/documents are not followed.


### Is it a breaking issue?

No

### Solution description

Checked the condition drop the chart side row selection in sample level

### Output screenshots

NA


### Additional checklist

- Did you run the automation against your fix? NO

- Is there any API name change? NO

- Is there any existing behavior change of other features due to this code change? NO

- Does your new code introduce new warnings or binding errors? NO

- Does your code pass all FxCop and StyleCop rules? NA

- Did you record this case in the unit test or UI test? NO
